### PR TITLE
Allow mocking a query with a param that is null

### DIFF
--- a/NSubstitute.DbConnection/NSubstitute.DbConnection.Tests/QueryParameterMatchingTests.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection.Tests/QueryParameterMatchingTests.cs
@@ -85,6 +85,26 @@ public class QueryParameterMatchingTests
     }
 
     [Test]
+    public void ShouldReplaceSingleNullParameterValue()
+    {
+        var mockConnection = Substitute.For<IDbConnection>().SetupCommands();
+        var commandText = "select * from table where value = @id";
+
+        var record = new KeyValueRecord(1, null);
+        mockConnection.SetupQuery(commandText)
+            .WithParameter("value", null)
+            .Returns(record);
+
+        var reader = mockConnection.ExecuteReader(
+            command =>
+            {
+                command.CommandText = commandText;
+                command.AddParameter("value", DBNull.Value);
+            });
+        reader.AssertSingleRecord(record);
+    }
+
+    [Test]
     public void ShouldAddParametersOneByOne()
     {
         var mockConnection = Substitute.For<IDbConnection>().SetupCommands();

--- a/NSubstitute.DbConnection/NSubstitute.DbConnection/MockQuery.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection/MockQuery.cs
@@ -92,7 +92,7 @@
             {
                 if (!(command.Parameters[i] is DbParameter parameter) ||
                     !Parameters.TryGetValue(parameter.ParameterName, out var parameterValue) ||
-                    !Equals(parameterValue, parameter.Value))
+                    !DbEquals(parameterValue, parameter))
                 {
                     return false;
                 }
@@ -146,6 +146,16 @@
         {
             var queryInfo = GetQueryInfo(mockCommand);
             return RowCountSelector?.Invoke(queryInfo) ?? ResultSelectors.SelectMany(resultSelector => resultSelector.Rows(queryInfo)).Count();
+        }
+
+        private static bool DbEquals(object parameterValue, DbParameter parameter)
+        {
+            if (parameterValue == null && parameter.Value is DBNull)
+            {
+                return true;
+            }
+
+            return Equals(parameterValue, parameter.Value);
         }
 
         private static void SetupNextResult(DbDataReader reader, Func<CallInfo, bool> nextResult)


### PR DESCRIPTION
"null" should also match "DbNull" as that may be passed as a value to SQL