### PR TITLE
Add Throws() to throw exception on query

### DIFF
--- a/NSubstitute.DbConnection/NSubstitute.DbConnection.Dapper.Tests/DapperQueryAsyncTests.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection.Dapper.Tests/DapperQueryAsyncTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Linq;
 using System.Threading.Tasks;
@@ -47,5 +48,21 @@ public class DapperQueryAsyncTests
         result.Count.Should().Be(1);
         result[0].Key.Should().Be(1);
         result[0].Value.Should().Be("abc");
+    }
+
+    [Test]
+    public async Task ShouldMockQueryAsyncThrow()
+    {
+        var mockConnection = Substitute.For<IDbConnection>().SetupCommands();
+        var expectedException = new Exception();
+        mockConnection.SetupQuery("delete from table")
+            .Throws(expectedException);
+
+        using var command = mockConnection.CreateCommand();
+        command.CommandText = "delete from table";
+        mockConnection.Open();
+
+        var act = async () => await mockConnection.QueryAsync("delete from table");
+        (await act.Should().ThrowAsync<Exception>()).And.Should().Be(expectedException);
     }
 }

--- a/NSubstitute.DbConnection/NSubstitute.DbConnection.Dapper.Tests/DapperQueryTests.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection.Dapper.Tests/DapperQueryTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Data;
 using System.Linq;
 using Dapper;
@@ -48,5 +49,21 @@ public class DapperQueryTests
         result.Count.Should().Be(1);
         result[0].Key.Should().Be(1);
         result[0].Value.Should().Be("abc");
+    }
+
+    [Test]
+    public void ShouldMockQueryThrow()
+    {
+        var mockConnection = Substitute.For<IDbConnection>().SetupCommands();
+        var expectedException = new Exception();
+        mockConnection.SetupQuery("delete from table")
+            .Throws(expectedException);
+
+        using var command = mockConnection.CreateCommand();
+        command.CommandText = "delete from table";
+        mockConnection.Open();
+
+        var act = () => mockConnection.Query("delete from table");
+        act.Should().Throw<Exception>().And.Should().Be(expectedException);
     }
 }

--- a/NSubstitute.DbConnection/NSubstitute.DbConnection.Tests/QueryTests.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection.Tests/QueryTests.cs
@@ -156,4 +156,42 @@ public class QueryTests
 
         callCount.Should().Be(resultSetCount);
     }
+
+    [Test]
+    public void ShouldThrow()
+    {
+        var mockConnection = Substitute.For<DbConnection>().SetupCommands();
+        var expectedException = new Exception();
+        mockConnection.SetupQuery("delete from table")
+            .Throws(expectedException);
+
+        using var command = mockConnection.CreateCommand();
+        command.CommandText = "delete from table";
+        mockConnection.Open();
+
+        var act = () => command.ExecuteReader();
+        act.Should().Throw<Exception>().And.Should().Be(expectedException);
+    }
+
+    [TestCase(0)]
+    [TestCase(1)]
+    [TestCase(2)]
+    [TestCase(4)]
+    [TestCase(8)]
+    public void ShouldThrowDependOnParameters(int id)
+    {
+        var mockConnection = Substitute.For<DbConnection>().SetupCommands();
+        var expectedException = new Exception($"failed to delete record with {id}");
+        mockConnection.SetupQuery("delete from table where id=@id")
+            .WithParameter("id", id)
+            .Throws(expectedException);
+
+        using var command = mockConnection.CreateCommand();
+        command.CommandText = "delete from table where id=@id";
+        command.AddParameter("id", id);
+        mockConnection.Open();
+
+        var act = () => command.ExecuteReader();
+        act.Should().Throw<Exception>().And.Should().Be(expectedException);
+    }
 }

--- a/NSubstitute.DbConnection/NSubstitute.DbConnection/IMockQueryBuilder.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection/IMockQueryBuilder.cs
@@ -68,5 +68,14 @@
         /// </summary>
         /// <param name="rowCountSelector">Returns the row count</param>
         void Affects(Func<QueryInfo, int> rowCountSelector);
+
+        /// <summary>
+        /// Specifies the exception that the query will throw
+        /// </summary>
+        /// <typeparam name="T">The type of the exception. Should be a derived type of <see cref="Exception"/></typeparam>
+        /// <typeparam name="exception">The exception</typeparam>
+        /// <returns>The result builder</returns>
+        void Throws<T>(T exception)
+            where T : Exception;
     }
 }

--- a/NSubstitute.DbConnection/NSubstitute.DbConnection/MockQuery.cs
+++ b/NSubstitute.DbConnection/NSubstitute.DbConnection/MockQuery.cs
@@ -71,6 +71,9 @@
 
         public void Affects(Func<QueryInfo, int> rowCountSelector) => RowCountSelector = rowCountSelector;
 
+        public void Throws<T>(T exception)
+            where T : Exception => ResultSelectors.Add((typeof(T), _ => { throw exception; }));
+
         public bool Matches(IDbCommand command)
         {
             if (!CommandTextMatcher(command.CommandText))

--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Use `.ThenReturns()` to set up second and subsequent result sets for your query:
     reader["Wheat"].Should().Be(4);
 ```
 
+## Throws an exception
+
+Use `.Throws()` to simulate the scenario when an exception is expected.
+
+```
+    mockConnection.SetupQuery("delete from TableWithTriggerPreventDelete")
+        .Throws(new Exception());
+```
+
 ## Further examples
 
 Check out the test fixtures in `NSubstitute.DbConnection.Tests` and `NSubstitute.DbConnection.Dapper.Tests` for working examples of the full set of supported functionality.


### PR DESCRIPTION
Added a new method `Throws()` to simulate the scenario when an exception is expected.

An ideal implementation would change how `MockQuery.ResultSelectors` works but I think it's too much work for a small request.